### PR TITLE
Use correct launch config name when checking if launch config exists

### DIFF
--- a/src/lib/ah/ah-launch
+++ b/src/lib/ah/ah-launch
@@ -66,7 +66,9 @@ asg_info=$(ah_asg_info $AH_ENV)
 
 ah_info "Checking autoscaling group exists..."
 
-if [[ -n "$(ah_asg_launch_config_name "$asg_info")" ]]; then
+AH_ASG_LAUNCH_CONFIG_NAME=$(ah_asg_launch_config_name "$asg_info")
+
+if [[ -n "$AH_ASG_LAUNCH_CONFIG_NAME" ]]; then
   ah_success "[Y]\n"
   update=true
 
@@ -74,9 +76,8 @@ if [[ -n "$(ah_asg_launch_config_name "$asg_info")" ]]; then
   ah_check "SG exists" ah_sg_exists $AH_ENV || ah_die "aborted."
   ah_check "role exists" ah_role_exists $AH_ENV || ah_die "aborted."
   ah_check "instance profile exists" ah_instance_profile_exists $AH_ENV || ah_die "aborted."
-  ah_check "launch configuration exists" ah_launch_config_exists $AH_ENV || ah_die "aborted."
+  ah_check "launch configuration exists" ah_launch_config_exists "$AH_ASG_LAUNCH_CONFIG_NAME" || ah_die "aborted."
 
-  AH_ASG_LAUNCH_CONFIG_NAME=$(ah_asg_launch_config_name "$asg_info")
   AH_ASG_VPC_SUBNETS=$(ah_asg_vpc_subnets "$asg_info")
   AH_ASG_AZS=$(ah_asg_azs "$asg_info")
   AH_ASG_SAVED=$(set |grep '^AH_ASG_' |sort)

--- a/src/lib/ah/ah-terminate
+++ b/src/lib/ah/ah-terminate
@@ -25,12 +25,15 @@ if ah_check "launch configuration exists" ah_launch_config_exists $AH_ENV; then
 fi
 
 if ah_check "SG exists" ah_sg_exists $AH_ENV; then
-  echo -n "Deleting SG..."
-  aws ec2 delete-security-group \
-    --group-id $(ah_sg_id_by_name $AH_ENV) \
-    > /dev/null \
-    || ah_die "can't delete SG."
-  echo "done."
+  echo "Deleting SGs..."
+  ah_sg_id_by_name $AH_ENV | while read sg_id; do
+    echo -n "Deleting SG $sg_id..."
+    aws ec2 delete-security-group \
+      --group-id $sg_id \
+      > /dev/null \
+      || ah_die "can't delete SG."
+    echo " done."
+  done
 fi
 
 # sketch of how to get the ids of classic link sg in vpc


### PR DESCRIPTION
> NOTE: This PR sits atop #13. Both PRs are bug fixes we've made in the process of getting `ah` to work with the latest changes.

At some point, we changed the way that `ah` names launch configs. It used to just be the `$AH_ENV` name, but now we append some numbers on the end.

As a result, this line of code needed to be adjusted so that we're looking for the launch config name, not the env name.