### PR TITLE
Fix creation of launch config when using EC2 Classic Link

### DIFF
--- a/src/lib/ah/ah-launch
+++ b/src/lib/ah/ah-launch
@@ -66,7 +66,9 @@ asg_info=$(ah_asg_info $AH_ENV)
 
 ah_info "Checking autoscaling group exists..."
 
-if [[ -n "$(ah_asg_launch_config_name "$asg_info")" ]]; then
+AH_ASG_LAUNCH_CONFIG_NAME=$(ah_asg_launch_config_name "$asg_info")
+
+if [[ -n "$AH_ASG_LAUNCH_CONFIG_NAME" ]]; then
   ah_success "[Y]\n"
   update=true
 
@@ -74,9 +76,8 @@ if [[ -n "$(ah_asg_launch_config_name "$asg_info")" ]]; then
   ah_check "SG exists" ah_sg_exists $AH_ENV || ah_die "aborted."
   ah_check "role exists" ah_role_exists $AH_ENV || ah_die "aborted."
   ah_check "instance profile exists" ah_instance_profile_exists $AH_ENV || ah_die "aborted."
-  ah_check "launch configuration exists" ah_launch_config_exists $AH_ENV || ah_die "aborted."
+  ah_check "launch configuration exists" ah_launch_config_exists "$AH_ASG_LAUNCH_CONFIG_NAME" || ah_die "aborted."
 
-  AH_ASG_LAUNCH_CONFIG_NAME=$(ah_asg_launch_config_name "$asg_info")
   AH_ASG_VPC_SUBNETS=$(ah_asg_vpc_subnets "$asg_info")
   AH_ASG_AZS=$(ah_asg_azs "$asg_info")
   AH_ASG_SAVED=$(set |grep '^AH_ASG_' |sort)

--- a/src/lib/ah/ah-launch
+++ b/src/lib/ah/ah-launch
@@ -235,11 +235,11 @@ if ! $update; then
     the_vpc="VPC $AH_LC_CLASSIC_LINK_VPC"
     more_opts="--vpc-id ${AH_LC_CLASSIC_LINK_VPC}"
     # for classic link we create an sg in the vpc and in ec2 classic
-    ah_try -m "Creating SG in EC2 classic..." \
+    ec2c_sg_id=$(ah_try -m "Creating SG in EC2 classic..." \
       aws ec2 create-security-group \
-          --group-name $AH_ENV \
-          --description "Ah security group for the $AH_ENV environment, $AH_APP application." \
-          > /dev/null
+        --group-name $AH_ENV \
+        --description "Ah security group for the $AH_ENV environment, $AH_APP application." \
+        | jt GroupId %)
   else
     the_vpc="EC2 classic"
   fi
@@ -266,12 +266,22 @@ if ! $update || $lc_changed; then
     more_lc_opts="$more_lc_opts --classic-link-vpc-id $AH_LC_CLASSIC_LINK_VPC --classic-link-vpc-security-groups $sg_id"
   fi
 
+  # If we're classic linking, there are 2 SGs, and we only want to use the one
+  # in EC2 Classic when creating the launch configuration.
+  #
+  # (The ID of the other SG, the VPC one, is supplied as part of $more_lc_opts.)
+  if [[ -n "$ec2c_sg_id" ]]; then
+    lc_sg_ids="$ec2c_sg_id"
+  else
+    lc_sg_ids=$(ah_sg_id_by_name $AH_ENV)
+  fi
+
   ah_retry -m "Creating launch configuration..." \
     aws autoscaling create-launch-configuration \
       --launch-configuration-name $AH_LC_NAME_NEW \
       --image-id $AH_LC_IMAGE_ID \
       --key-name $AH_LC_KEY_NAME \
-      --security-groups $(ah_sg_id_by_name $AH_ENV) \
+      --security-groups "$lc_sg_ids" \
       --user-data "$(cat $AH_SHR/user-data.sh |envsubst '$AH_APP:$AH_ENV:$AH_BUCKET:$AH_MASTER_REGION')" \
       --instance-type $AH_LC_INSTANCE_TYPE \
       --iam-instance-profile $(ah_instance_profile_arn ah/$AH_ENV) \

--- a/src/lib/ah/ah-terminate
+++ b/src/lib/ah/ah-terminate
@@ -25,12 +25,15 @@ if ah_check "launch configuration exists" ah_launch_config_exists $AH_ENV; then
 fi
 
 if ah_check "SG exists" ah_sg_exists $AH_ENV; then
-  echo -n "Deleting SG..."
-  aws ec2 delete-security-group \
-    --group-id $(ah_sg_id_by_name $AH_ENV) \
-    > /dev/null \
-    || ah_die "can't delete SG."
-  echo "done."
+  echo "Deleting SGs..."
+  ah_sg_id_by_name $AH_ENV | while read sg_id; do
+    echo -n "Deleting SG $sg_id..."
+    aws ec2 delete-security-group \
+      --group-id $sg_id \
+      > /dev/null \
+      || ah_die "can't delete SG."
+    echo " done."
+  done
 fi
 
 # sketch of how to get the ids of classic link sg in vpc


### PR DESCRIPTION
> NB: This PR sits atop #16, which sits atop #13. All three PRs are bug fixes that we've made in the process of getting `ah` to work with the latest changes.

When you want to use EC2 Classic Link, you create 2 SGs:

- One in the VPC to which you want to classic link.
- One that's not in a VPC.

Then you use `aws autoscaling create-launch-configuration` to create a launch config, and in the arguments, there are two places where you supply an SG ID:

* `--security-groups` is where the non-VPC SG ID goes
* `--classic-link-vpc-security-groups` is where the VPC SG ID goes

We're currently doing the `--classic-link-vpc-security-groups` one right, but we're supplying _both_ SG IDs for `--security-groups`, which results in an error from the AWS CLI tool because the SGs don't all have the same VPC ID.

Instead, we want to do what's described above and only supply the non-VPC SG ID for `--security-groups`.