### PR TITLE
ah launch: capture and reuse an existing env's configuration

### DIFF
--- a/doc/ah-client.1.html
+++ b/doc/ah-client.1.html
@@ -117,7 +117,7 @@ law.</p>
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>February 2017</li>
+    <li class='tc'>2017-08-02</li>
     <li class='tr'>ah-client(1)</li>
   </ol>
 

--- a/doc/ah.1.html
+++ b/doc/ah.1.html
@@ -159,7 +159,9 @@ by the last <code>putvar</code>.</p></dd>
 associated with git revision <var>rev</var> (or <code>HEAD</code> if not provided). See the
 <code>SPECIFYING REVISIONS</code> section of the <code>git-rev-parse</code>(1) manual for details.</p></dd>
 <dt class="flush"><code>getsha</code></dt><dd><p>Print the currently configured deploy SHA for the current environment.</p></dd>
-<dt class="flush"><code>launch</code></dt><dd><p>Interactive command to create AWS resources for a new environment.</p></dd>
+<dt><code>launch</code> [<code>-t</code> <var>file</var>]</dt><dd><p>Interactive (by default) command to create AWS resources for a new
+environment. When the <code>-t</code> option is provided, configuration is loaded
+from a file instead of being obtained interactively.</p></dd>
 <dt><code>terminate</code></dt><dd><p>Destroy all AWS resources associated with the current environment. Only
 resources managed by <code>ah</code> will be affected.</p></dd>
 <dt><code>secrets</code> [<code>-a</code>]</dt><dd><p>Print all S3 secrets to which the current environment has access, or if
@@ -225,7 +227,7 @@ law.</p>
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>May 2017</li>
+    <li class='tc'>2017-08-02</li>
     <li class='tr'>ah(1)</li>
   </ol>
 

--- a/doc/ah.1.md
+++ b/doc/ah.1.md
@@ -110,8 +110,10 @@ environment before any other environment scope commands are attempted.
   * `getsha`:
     Print the currently configured deploy SHA for the current environment.
 
-  * `launch`:
-    Interactive command to create AWS resources for a new environment.
+  * `launch` [`-t` <file>]:
+    Interactive (by default) command to create AWS resources for a new
+    environment. When the `-t` option is provided, configuration is loaded
+    from a file instead of being obtained interactively.
 
   * `terminate`:
     Destroy all AWS resources associated with the current environment. Only

--- a/src/lib/ah/ah-launch
+++ b/src/lib/ah/ah-launch
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
 
+while getopts ":t:" opt; do
+  case "${opt}" in
+    t) template_env="$OPTARG"
+  esac
+done
+
+if [[ -n "$template_env" ]] && [ ! -f "$template_env" ]; then
+  ah_die "Template file \"$template_env\" doesn't exist!"
+fi
+
 role_policy_json=$(cat <<EOT
 {
   "Version": "2012-10-17",
@@ -108,7 +118,7 @@ else
   ah_check "launch configuration does not already exist" ah_not ah_launch_config_exists $AH_ENV || ah_die "aborted."
 fi
 
-if ! $update; then
+if ! $update && [[ -z "$template_env" ]]; then
   while ah_select -p "Org to use as a template? " template "$avail_orgs"; do
     [[ $template ]] && break
   done
@@ -120,6 +130,12 @@ if ! $update; then
 fi
 
 while true; do
+  if [[ -n "$template_env" ]]; then
+    ah_try -m "Loading configuration from $template_env..." \
+      . <(cat $template_env | grep . | sed 's@^@export @')
+    break
+  fi
+
   if ! $update; then
     while ah_select -p "Launch into VPC? " AH_SG_VPC "$avail_vpcs"; do
       [[ $AH_SG_VPC ]] && break
@@ -186,7 +202,7 @@ done
 
 mkdir -p .ah || ah_die "can't create .ah directory"
 ah_try -m "Writing .ah/$AH_ENV.conf file..." \
-  echo "$vars" > .ah/$AH_ENV.conf
+  echo "$vars" | grep -v 'AH_ENV=' > .ah/$AH_ENV.conf
 
 AH_ASG_NEW=$(set |grep '^AH_ASG_' |grep -v '^AH_ASG_SAVED=' |sort)
 AH_LC_NEW=$(set |grep '^AH_LC_' |grep -v '^AH_LC_SAVED=' |sort)

--- a/src/lib/ah/ah-launch
+++ b/src/lib/ah/ah-launch
@@ -184,6 +184,10 @@ while true; do
   echo
 done
 
+mkdir -p .ah || ah_die "can't create .ah directory"
+ah_try -m "Writing .ah/$AH_ENV.conf file..." \
+  echo "$vars" > .ah/$AH_ENV.conf
+
 AH_ASG_NEW=$(set |grep '^AH_ASG_' |grep -v '^AH_ASG_SAVED=' |sort)
 AH_LC_NEW=$(set |grep '^AH_LC_' |grep -v '^AH_LC_SAVED=' |sort)
 

--- a/src/man/man1/ah-client.1
+++ b/src/man/man1/ah-client.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "AH\-CLIENT" "1" "February 2017" "" "AH MANUAL"
+.TH "AH\-CLIENT" "1" "2017-08-02" "" "AH MANUAL"
 .
 .SH "NAME"
 \fBah\-client\fR \- simple, service oriented management of AWS resources

--- a/src/man/man1/ah.1
+++ b/src/man/man1/ah.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "AH" "1" "May 2017" "" "AH MANUAL"
+.TH "AH" "1" "2017-08-02" "" "AH MANUAL"
 .
 .SH "NAME"
 \fBah\fR \- simple, service oriented management of AWS resources
@@ -101,8 +101,8 @@ Set the configured deploy SHA for the current environment to the SHA associated 
 Print the currently configured deploy SHA for the current environment\.
 .
 .TP
-\fBlaunch\fR
-Interactive command to create AWS resources for a new environment\.
+\fBlaunch\fR [\fB\-t\fR \fIfile\fR]
+Interactive (by default) command to create AWS resources for a new environment\. When the \fB\-t\fR option is provided, configuration is loaded from a file instead of being obtained interactively\.
 .
 .TP
 \fBterminate\fR


### PR DESCRIPTION
This will allow you to clone an existing `ah` environment (except for any additions to the environment made after running `ah launch` to launch the environment).

When a new environment like `foo-ah-prod` is launched via `ah launch`, configuration options are chosen interactively, and then written to a file `.ah/foo-ah-prod.conf`.

(This also works for existing environments when you just want to generate the .conf file; you can ENTER through the interactive prompts to go with the options already selected for that environment.)

Then to clone that environment, you can run:

```bash
$ ah env foo-ah-prod2
$ ah launch -t .ah/foo-ah-prod.conf
```