### PR TITLE
Fixes for OS X version of awk.

### DIFF
--- a/src/lib/ah/ah-launch
+++ b/src/lib/ah/ah-launch
@@ -42,11 +42,11 @@ avail_azs=$(aws ec2 describe-availability-zones \
 avail_vpcs=$(aws ec2 describe-vpcs \
   |jt Vpcs [ VpcId % ] [ Tags [ Key % ] [ Value % ] ] \
   |sort \
-  |awk -F' ' '$2 == "Name" {print $1 "\t" $3}')
+  |awk -F ' ' '$2 == "Name" {print $1 "\t" $3}')
 
 avail_subnets=$(aws ec2 describe-subnets \
   |jt Subnets [ VpcId % ] [ SubnetId % ] [ AvailabilityZone % ] [ CidrBlock % ] \
-  |awk -F'	' '{print $1 "\t" $2 "\t" $3 " " $4}' \
+  |awk -F '	' '{print $1 "\t" $2 "\t" $3 " " $4}' \
   |sort -k3)
 
 avail_images=$(aws ec2 describe-images --owners $(ah_account_id) \
@@ -139,7 +139,7 @@ while true; do
         || break
     done
   else
-    sn=$(echo "$avail_subnets" |awk -F'	' -vVPC=$AH_SG_VPC '$1 == VPC {print $2 "\t" $3}')
+    sn=$(echo "$avail_subnets" |awk -F '	' -v VPC=$AH_SG_VPC '$1 == VPC {print $2 "\t" $3}')
     [[ ! $sn ]] && ah_warning "VPC contains no subnets" && continue
     while true; do
       ah_select -mp "Subnets for VPC? " AH_ASG_VPC_SUBNETS "$sn" \
@@ -170,7 +170,7 @@ while true; do
     [[ "$AH_LC_INSTANCE_TYPE" ]] && break
   done
 
-  vars=$(set |grep -E "^AH_($(if [[ -z "$AH_ASG_VPC_SUBNETS" ]] ; then echo "ASG_AZS|" ; else echo "ASG_VPC_SUBNETS|" ; fi)|BILLING_GROUP|BILLING_PROJECT|ENV|LC_IMAGE_ID|LC_KEY_NAME|LC_INSTANCE_TYPE|SG_VPC|ASG_VPC_SUBNETS|LC_CLASSIC_LINK_VPC)=" |sort)
+  vars=$(set |grep -E "^AH_($(if [[ -z "$AH_ASG_VPC_SUBNETS" ]] ; then echo "ASG_AZS|" ; else echo "ASG_VPC_SUBNETS|" ; fi)BILLING_GROUP|BILLING_PROJECT|ENV|LC_IMAGE_ID|LC_KEY_NAME|LC_INSTANCE_TYPE|SG_VPC|ASG_VPC_SUBNETS|LC_CLASSIC_LINK_VPC)=" |sort)
 
   echo
   echo "$vars"

--- a/src/lib/ah/ah-secrets
+++ b/src/lib/ah/ah-secrets
@@ -20,7 +20,7 @@ shift $((OPTIND-1))
 aws iam list-policies \
   | jt . [ Path % ] [ PolicyName % ] \
   | awk '$1 == "/ah/secrets/" {print $2}' \
-  | awk -F= "\$2 == \"$(ah_var AH_ENV)\" {print \$1}" \
+  | awk -F = "\$2 == \"$(ah_var AH_ENV)\" {print \$1}" \
   | while read key; do
       val=$(aws s3 cp s3://$(ah_var AH_BUCKET)/secrets/$key - --region $AH_MASTER_REGION 2>/dev/null) || continue
       echo "${key}=$val"

--- a/src/lib/ah/ah-terminate
+++ b/src/lib/ah/ah-terminate
@@ -41,7 +41,7 @@ ignore=$(cat <<EOT
 aws ec2 describe-security-groups \
   --group-ids $(aws autoscaling describe-launch-configurations --launch-configuration-names "$AH_ENV" |jt . ClassicLinkVPCSecurityGroups %) \
   |jt . [ GroupId % ] [ GroupName % ] \
-  |awk -F'	' "\$2 == \"$AH_ENV\" {print \$1}"
+  |awk -F '	' "\$2 == \"$AH_ENV\" {print \$1}"
 EOT
 )
 


### PR DESCRIPTION
Arguments need a space between switch and value. E.g. `-v foo=bar` rather
than `-vfoo=bar`.